### PR TITLE
feat(eval): evaluator token_usage_billed — token de input faturado real

### DIFF
--- a/src/evaluations/core/eval/utils.py
+++ b/src/evaluations/core/eval/utils.py
@@ -59,6 +59,7 @@ def parse_reasoning_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, A
                 "total_tokens": msg.get("total_tokens"),
                 "prompt_tokens": msg.get("prompt_tokens"),
                 "completion_tokens": msg.get("completion_tokens"),
+                "cached_tokens": msg.get("cached_tokens"),
                 "step_count": msg.get("step_count"),
                 "steps_messages": msg.get("steps_messages"),
                 "run_ids": msg.get("run_ids"),

--- a/src/evaluations/core/experiments/eai/evaluators/__init__.py
+++ b/src/evaluations/core/experiments/eai/evaluators/__init__.py
@@ -91,6 +91,11 @@ from src.evaluations.core.experiments.eai.evaluators.token_usage_total import (
     TokenUsageTotalEvaluator,
 )
 
+from src.evaluations.core.experiments.eai.evaluators.token_usage_billed import (
+    TokenUsageBilledEvaluator,
+    TokenUsageBilledOneTurnEvaluator,
+)
+
 # Typesense evaluators (new)
 from src.evaluations.core.experiments.eai.evaluators.typesense import (
     BaseTypesenseEvaluator,
@@ -130,6 +135,8 @@ __all__ = [
     "CriticalFactAccuracyEvaluator",
     "HallucinationFlagEvaluator",
     "TokenUsageTotalEvaluator",
+    "TokenUsageBilledEvaluator",
+    "TokenUsageBilledOneTurnEvaluator",
     # Typesense evaluators (new)
     "BaseTypesenseEvaluator",
     "TypesenseHasMatchEvaluator",

--- a/src/evaluations/core/experiments/eai/evaluators/token_usage_billed.py
+++ b/src/evaluations/core/experiments/eai/evaluators/token_usage_billed.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+"""
+Evaluator de tokens FATURADOS reais (billing footprint), distinto do
+``token_usage_total`` (que estima chars/4 do transcript visível — proxy de
+tamanho-de-memória, NÃO o token cobrado pela API).
+
+Lê o ``usage_statistics`` que o engine já emite (``prompt_tokens`` =
+``prompt_token_count`` do Vertex, somado por turno em
+``message_formatter.calculate_usage_statistics``) — o INPUT realmente cobrado,
+incluindo system prompt + tools + memória re-submetida, que o chars/4 não enxerga.
+Quando o real vier 0/ausente, cai num piso chars/4 marcado. Também expõe o split de
+cache (``cached_tokens`` = ``cached_content_token_count``), que resolve a dúvida
+"75% vs 90% de desconto de cache" do estudo de custos.
+
+A lógica pura fica em ``src/utils/token_billing.py`` (sem deps pesadas, unit-testável).
+Métrica INFORMATIVA (não trava o gate — ver ``comment_eval_results.py::INFORMATIONAL_METRICS``).
+"""
+
+from src.evaluations.core.eval import (
+    AgentResponse,
+    BaseMultipleTurnEvaluator,
+    BaseOneTurnEvaluator,
+    EvaluationResult,
+    EvaluationTask,
+    MultiTurnEvaluationInput,
+)
+from src.utils.token_billing import aggregate_billed
+from src.utils.log import logger
+
+
+class TokenUsageBilledEvaluator(BaseMultipleTurnEvaluator):
+    """Tokens de input FATURADOS reais ao longo da conversa (multi-turn)."""
+
+    name = "token_usage_billed"
+
+    async def evaluate(
+        self, agent_response: MultiTurnEvaluationInput, task: EvaluationTask
+    ) -> EvaluationResult:
+        try:
+            traces = [turn.agent_reasoning_trace for turn in agent_response.transcript]
+            result = aggregate_billed(traces)
+            return EvaluationResult(
+                score=result["score"],
+                annotations=str(result["annotations"]),
+                has_error=False,
+                error_message=None,
+            )
+        except Exception as e:  # noqa: BLE001
+            logger.error(f"Erro ao avaliar token_usage_billed (multi): {e}", exc_info=True)
+            return EvaluationResult(
+                score=None, annotations=None, has_error=True, error_message=str(e)
+            )
+
+
+class TokenUsageBilledOneTurnEvaluator(BaseOneTurnEvaluator):
+    """Tokens de input FATURADOS reais de um único turno (one-turn).
+
+    Mesmo ``name`` do multi-turn — agrega no mesmo métrico através dos experiments.
+    """
+
+    name = "token_usage_billed"
+
+    async def evaluate(
+        self, agent_response: AgentResponse, task: EvaluationTask
+    ) -> EvaluationResult:
+        try:
+            result = aggregate_billed([agent_response.reasoning_trace])
+            return EvaluationResult(
+                score=result["score"],
+                annotations=str(result["annotations"]),
+                has_error=False,
+                error_message=None,
+            )
+        except Exception as e:  # noqa: BLE001
+            logger.error(f"Erro ao avaliar token_usage_billed (one): {e}", exc_info=True)
+            return EvaluationResult(
+                score=None, annotations=None, has_error=True, error_message=str(e)
+            )

--- a/src/evaluations/core/experiments/eai/run_disaster_eval.py
+++ b/src/evaluations/core/experiments/eai/run_disaster_eval.py
@@ -16,6 +16,7 @@ from src.evaluations.core.experiments.eai.evaluators import (
     ToolUsageEvaluator,
     CivilDefenseDisasterResponseEvaluator,
     ResponseQualityEvaluator,
+    TokenUsageBilledOneTurnEvaluator,
 )
 from src.evaluations.core.experiments.eai.evaluators.prompts import (
     prompt_data,
@@ -59,6 +60,7 @@ async def run_experiment(reasoning_engine_id: str | None = None):
         ToolUsageEvaluator(judge_client),
         CivilDefenseDisasterResponseEvaluator(judge_client),
         ResponseQualityEvaluator(judge_client),
+        TokenUsageBilledOneTurnEvaluator(judge_client),
     ]
 
     evaluator_names = [e.name for e in evaluators_to_run]

--- a/src/evaluations/core/experiments/eai/run_equipments.py
+++ b/src/evaluations/core/experiments/eai/run_equipments.py
@@ -18,6 +18,7 @@ from src.evaluations.core.experiments.eai.evaluators import (
     EquipmentsSpeedEvaluator,
     EquipmentsToolsEvaluator,
     EquipmentsCategoriesEvaluator,
+    TokenUsageBilledEvaluator,
 )
 from src.evaluations.core.experiments.eai.evaluators.prompts import (
     prompt_data,
@@ -66,6 +67,7 @@ async def run_experiment(reasoning_engine_id: str | None = None):
         EquipmentsCorrectnessEvaluator(judge_client),
         EquipmentsSpeedEvaluator(judge_client),
         EquipmentsToolsEvaluator(judge_client),
+        TokenUsageBilledEvaluator(judge_client),
     ]
 
     evaluator_names = [e.name for e in evaluators_to_run]

--- a/src/evaluations/core/experiments/eai/run_memory_experiment.py
+++ b/src/evaluations/core/experiments/eai/run_memory_experiment.py
@@ -18,6 +18,7 @@ from src.evaluations.core.experiments.eai.evaluators import (
     CriticalFactAccuracyEvaluator,
     HallucinationFlagEvaluator,
     TokenUsageTotalEvaluator,
+    TokenUsageBilledEvaluator,
 )
 from src.evaluations.core.experiments.eai.evaluators.prompts import (
     prompt_data,
@@ -96,6 +97,7 @@ async def run_experiment(
         CriticalFactAccuracyEvaluator(judge_client),
         HallucinationFlagEvaluator(judge_client),
         TokenUsageTotalEvaluator(judge_client),
+        TokenUsageBilledEvaluator(judge_client),
     ]
 
     evaluator_names = [e.name for e in evaluators_to_run]

--- a/src/evaluations/core/experiments/eai/run_servicos.py
+++ b/src/evaluations/core/experiments/eai/run_servicos.py
@@ -28,6 +28,7 @@ from src.evaluations.core.experiments.eai.evaluators import (
     LinkCompletenessEvaluator,
     ToolCallingLinkCompletenessEvaluator,
     AnswerCompletenessOldEvaluator,
+    TokenUsageBilledOneTurnEvaluator,
 )
 from src.evaluations.core.experiments.eai.evaluators.prompts import (
     prompt_data,
@@ -76,6 +77,7 @@ async def run_experiment(reasoning_engine_id: str | None = None):
         MessageLengthEvaluator(judge_client),
         ProactivityEvaluator(judge_client),
         WhatsAppFormatEvaluator(judge_client),
+        TokenUsageBilledOneTurnEvaluator(judge_client),
         # HasLinkEvaluator(judge_client),
         # LinkCompletenessEvaluator(judge_client),
         # ToolCallingLinkCompletenessEvaluator(judge_client),

--- a/src/services/agent_engine/message_formatter.py
+++ b/src/services/agent_engine/message_formatter.py
@@ -424,6 +424,7 @@ class LangGraphMessageFormatter:
         output_tokens = 0
         total_tokens = 0
         thoughts_tokens = 0
+        cached_tokens = 0
         model_names = set()
 
         for msg in messages_to_process:
@@ -440,6 +441,9 @@ class LangGraphMessageFormatter:
 
             # thoughts (se houver)
             thoughts_tokens += int(usage_md.get("thoughts_token_count", 0) or 0)
+
+            # cached (prefixo servido do cache implícito do Vertex — pra split de custo)
+            cached_tokens += int(usage_md.get("cached_content_token_count", 0) or 0)
 
             # total (geralmente a soma, mas usamos o valor retornado se existir)
             msg_total = int(usage_md.get("total_token_count", 0) or 0)
@@ -466,6 +470,7 @@ class LangGraphMessageFormatter:
             "completion_tokens": total_output_tokens,  # Inclui pensamentos para refletir geração total
             "thoughts_tokens": thoughts_tokens,  # Novo campo para expor o total de tokens de pensamento
             "prompt_tokens": input_tokens,
+            "cached_tokens": cached_tokens,  # Parcela de prompt servida do cache implícito (cached_content_token_count)
             "total_tokens": total_tokens,
             "step_count": len(
                 {m.get("step_id") for m in self.processed_messages if m.get("step_id")}

--- a/src/utils/token_billing.py
+++ b/src/utils/token_billing.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+"""
+Lógica PURA do ``token_usage_billed`` — SEM imports pesados (config/bigquery/GCP),
+pra ser unit-testável sem o env de infra. As classes Evaluator (que importam as
+base classes pesadas) vivem em ``token_usage_billed.py`` e chamam ``aggregate_billed``.
+
+``token_usage_billed`` lê o token de INPUT realmente FATURADO (``prompt_tokens`` do
+``usage_statistics``, = ``prompt_token_count`` do Vertex, incluindo system prompt +
+tools + memória re-submetida) — distinto do ``token_usage_total``, que estima chars/4
+só do transcript visível. Quando o real vier 0/ausente num turno, usa um piso chars/4
+marcado. Também agrega o split de cache (``cached_tokens``).
+"""
+
+from typing import Any, Dict, List, Optional
+
+
+def estimate_floor_tokens(text: str) -> int:
+    """Piso chars/4 (mesma regra do ``token_usage_total.estimate_tokens_from_text``)."""
+    if not text:
+        return 0
+    return int(len(text.strip()) / 4)
+
+
+def find_usage_statistics(reasoning_trace: Optional[List[Any]]) -> Optional[Dict[str, Any]]:
+    """Acha o step ``usage_statistics`` num reasoning_trace e devolve seu content (dict)."""
+    if not reasoning_trace:
+        return None
+    for step in reasoning_trace:
+        if getattr(step, "message_type", None) == "usage_statistics":
+            content = getattr(step, "content", None)
+            if isinstance(content, dict):
+                return content
+    return None
+
+
+def estimate_floor_from_trace(reasoning_trace: Optional[List[Any]]) -> int:
+    """Piso chars/4 do texto visível do trace — usado SÓ quando o real não vem.
+
+    É um piso (subconta): não enxerga system prompt/tools/memória, que dominam o
+    input faturado. Serve pra o score não zerar em turnos sem usage real.
+    """
+    if not reasoning_trace:
+        return 0
+    total = 0
+    for step in reasoning_trace:
+        if getattr(step, "message_type", None) == "usage_statistics":
+            continue
+        content = getattr(step, "content", None)
+        if content:
+            total += estimate_floor_tokens(str(content))
+    return total
+
+
+def aggregate_billed(reasoning_traces: List[Optional[List[Any]]]) -> Dict[str, Any]:
+    """Agrega o token faturado real (com piso chars/4 onde faltar) sobre N turnos.
+
+    ``reasoning_traces`` = um trace por turno (one-turn → lista de 1). Devolve
+    ``{"score": <billed_prompt_tokens>, "annotations": {...}}``.
+    """
+    real_prompt = 0
+    estimated_prompt = 0
+    cached = 0
+    completion = 0
+    real_turns = 0
+    estimated_turns = 0
+    per_turn: List[Dict[str, Any]] = []
+
+    for idx, trace in enumerate(reasoning_traces):
+        usage = find_usage_statistics(trace)
+        prompt_real = int((usage or {}).get("prompt_tokens") or 0)
+
+        if prompt_real > 0:
+            cached_turn = int((usage or {}).get("cached_tokens") or 0)
+            real_prompt += prompt_real
+            completion += int((usage or {}).get("completion_tokens") or 0)
+            cached += cached_turn
+            real_turns += 1
+            per_turn.append(
+                {
+                    "turn": idx + 1,
+                    "method": "real",
+                    "prompt_tokens": prompt_real,
+                    "cached_tokens": cached_turn,
+                }
+            )
+        else:
+            floor = estimate_floor_from_trace(trace)
+            estimated_prompt += floor
+            estimated_turns += 1
+            per_turn.append(
+                {"turn": idx + 1, "method": "estimated_floor", "prompt_tokens": floor}
+            )
+
+    total_billed_prompt = real_prompt + estimated_prompt
+    uncached_prompt = max(real_prompt - cached, 0)
+    n_turns = len(reasoning_traces) or 1
+
+    annotations = {
+        "metric": "token_usage_billed",
+        "billed_prompt_tokens": total_billed_prompt,
+        "real_prompt_tokens": real_prompt,
+        "estimated_floor_prompt_tokens": estimated_prompt,
+        "completion_tokens": completion,
+        "cached_tokens": cached,
+        "uncached_prompt_tokens": uncached_prompt,
+        "cache_hit_ratio": round(cached / real_prompt, 4) if real_prompt else None,
+        "real_turns": real_turns,
+        "estimated_turns": estimated_turns,
+        "coverage": round(real_turns / n_turns, 4),
+        "breakdown_by_turn": per_turn,
+        "note": (
+            "score = prompt_tokens faturado real (usage_statistics) somado; "
+            "turnos sem usage real usam piso chars/4 (subconta). cached_tokens = "
+            "parcela servida do cache implícito do Vertex."
+        ),
+    }
+    return {"score": total_billed_prompt, "annotations": annotations}

--- a/tests/unit/test_token_billing.py
+++ b/tests/unit/test_token_billing.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+"""
+Testes da lógica pura do ``token_usage_billed`` (footprint de tokens FATURADOS).
+
+Importa SÓ o módulo core (sem deps pesadas de config/bigquery/GCP), então roda
+sem o env de infra.
+"""
+
+from src.utils.token_billing import (
+    aggregate_billed,
+    estimate_floor_tokens,
+    find_usage_statistics,
+)
+
+
+class _Step:
+    """Stub mínimo de ReasoningStep (message_type + content)."""
+
+    def __init__(self, message_type, content):
+        self.message_type = message_type
+        self.content = content
+
+
+def _usage_step(prompt, cached=0, completion=0, total=None):
+    return _Step(
+        "usage_statistics",
+        {
+            "prompt_tokens": prompt,
+            "cached_tokens": cached,
+            "completion_tokens": completion,
+            "total_tokens": total if total is not None else prompt + completion,
+        },
+    )
+
+
+def test_uses_real_billed_prompt_tokens_when_present():
+    """Com usage_statistics real, usa o prompt_tokens FATURADO, não chars/4."""
+    trace = [
+        _Step("reasoning_message", "um texto curto de raciocínio"),
+        _usage_step(prompt=36000, cached=9000, completion=200),
+    ]
+    out = aggregate_billed([trace])
+    a = out["annotations"]
+    assert out["score"] == 36000  # real, não o ~7 do chars/4 do texto
+    assert a["real_prompt_tokens"] == 36000
+    assert a["cached_tokens"] == 9000
+    assert a["uncached_prompt_tokens"] == 27000
+    assert a["cache_hit_ratio"] == 0.25  # 9000/36000
+    assert a["real_turns"] == 1 and a["estimated_turns"] == 0
+    assert a["coverage"] == 1.0
+
+
+def test_falls_back_to_floor_when_usage_missing_or_zero():
+    """Sem usage real (ou prompt_tokens=0), cai no piso chars/4, marcado."""
+    text = "x" * 400  # 400 chars → ~100 tok no piso
+    trace_missing = [_Step("reasoning_message", text)]
+    trace_zero = [_Step("reasoning_message", text), _usage_step(prompt=0)]
+    out = aggregate_billed([trace_missing, trace_zero])
+    a = out["annotations"]
+    assert a["real_prompt_tokens"] == 0
+    assert a["estimated_floor_prompt_tokens"] == 200  # 2 × ~100
+    assert a["estimated_turns"] == 2 and a["real_turns"] == 0
+    assert a["coverage"] == 0.0
+    assert a["cache_hit_ratio"] is None
+    assert all(t["method"] == "estimated_floor" for t in a["breakdown_by_turn"])
+
+
+def test_mixed_turns_sum_real_plus_floor_with_coverage():
+    """Conversa com turno real + turno sem usage: soma real + piso, coverage 0.5."""
+    real = [_usage_step(prompt=30000, cached=6000)]
+    miss = [_Step("tool_call_message", "y" * 800)]  # ~200 no piso
+    out = aggregate_billed([real, miss])
+    a = out["annotations"]
+    assert a["real_prompt_tokens"] == 30000
+    assert a["estimated_floor_prompt_tokens"] == 200
+    assert out["score"] == 30200
+    assert a["cached_tokens"] == 6000
+    assert a["coverage"] == 0.5
+
+
+def test_estimate_floor_tokens_rule():
+    assert estimate_floor_tokens("") == 0
+    assert estimate_floor_tokens("abcd") == 1  # 4 chars / 4
+    assert estimate_floor_tokens("a" * 400) == 100
+
+
+def test_find_usage_statistics_picks_the_right_step():
+    trace = [_Step("reasoning_message", "nada"), _usage_step(prompt=123)]
+    found = find_usage_statistics(trace)
+    assert found is not None and found["prompt_tokens"] == 123
+    assert find_usage_statistics([]) is None
+    assert find_usage_statistics(None) is None


### PR DESCRIPTION
Adiciona a métrica `token_usage_billed`: o token de input **realmente FATURADO** (do `usage_statistics` que o engine já emite = `prompt_token_count` do Vertex, incluindo system prompt + tools + memória), com piso chars/4 marcado só quando o real vier 0/ausente. Fecha o split de custo exato por turno que o estudo de custos (§6.5) deixou aberto — o `token_usage_total` existente é proxy de transcript (chars/4), **não** o token cobrado.

- `calculate_usage_statistics` agrega `cached_content_token_count` → `cached_tokens` (split de cache: resolve a dúvida 75% vs 90% de desconto).
- `src/utils/token_billing.py`: lógica **pura** (sem deps pesadas, unit-testável sem o env de infra) — **5 testes**.
- `TokenUsageBilledEvaluator` (multi: memory+equipments) + `TokenUsageBilledOneTurnEvaluator` (one: servicos+disaster), mesmo `name`, registrados nos 4 runners.

**Par do engine PR #110** que classifica a métrica como informativa (não trava o gate). O eval-on-deploy faz checkout do evals `ref: staging`, então esta mudança propaga no próximo eval. Code-reviewer: approve.

Reviewed-by: claude-code-review